### PR TITLE
[StackMoreThings] Stack tools except for tools that have attachments

### DIFF
--- a/StackMoreThings/CommonUtils.cs
+++ b/StackMoreThings/CommonUtils.cs
@@ -1,6 +1,8 @@
 using System.Runtime.CompilerServices;
+using Netcode;
 using StardewModdingAPI;
 using StardewValley;
+using StardewValley.Enchantments;
 
 namespace StackMoreThings;
 
@@ -49,5 +51,42 @@ static class CommonUtils
     )
     {
         monitor.Log($"Failed in {filePath}:{memberName}:{lineNumber}:\n{ex}", LogLevel.Error);
+    }
+
+    private static bool enchantListContainsAll(
+        NetList<BaseEnchantment, NetRef<BaseEnchantment>> list,
+        NetList<BaseEnchantment, NetRef<BaseEnchantment>> otherList
+    )
+    {
+        for (int i = 0; i < list.Count; i++)
+        {
+            var found = false;
+            for (int j = 0; j < otherList.Count; j++)
+            {
+                if (
+                    list[i].GetType() == otherList[j].GetType()
+                    && list[i].GetLevel() == otherList[j].GetLevel()
+                )
+                {
+                    found = true;
+                    break;
+                }
+            }
+            if (!found)
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public static bool equalEnchantLists(
+        NetList<BaseEnchantment, NetRef<BaseEnchantment>> list,
+        NetList<BaseEnchantment, NetRef<BaseEnchantment>> otherList
+    )
+    {
+        return list.Count == otherList.Count
+            && enchantListContainsAll(list, otherList)
+            && enchantListContainsAll(otherList, list);
     }
 }

--- a/StackMoreThings/ModConfig.cs
+++ b/StackMoreThings/ModConfig.cs
@@ -7,6 +7,7 @@ public sealed class ModConfig
     public int MaxStackSize { get; set; } = 9999;
     public bool Trinkets { get; set; } = true;
     public bool Rings { get; set; } = true;
+    public bool Tools { get; set; } = true;
     public bool Weapons { get; set; } = true;
     public bool Furniture { get; set; } = true;
     public bool Tackle { get; set; } = true;

--- a/StackMoreThings/ModEntry.cs
+++ b/StackMoreThings/ModEntry.cs
@@ -88,6 +88,7 @@ internal sealed class ModEntry : Mod
                     "Clothing",
                     Game1.content.LoadString("Strings\\StringsFromCSFiles:category_clothes")
                 },
+                { "Tools", this.Helper.Translation.Get("Tools") },
             };
         foreach (var configName in configNames)
         {

--- a/StackMoreThings/Patches/MeleeWeapon.cs
+++ b/StackMoreThings/Patches/MeleeWeapon.cs
@@ -1,7 +1,5 @@
 using HarmonyLib;
-using Netcode;
 using StardewValley;
-using StardewValley.Enchantments;
 using StardewValley.Tools;
 
 namespace StackMoreThings.Patches;
@@ -28,41 +26,12 @@ public static class MeleeWeaponCanStackWith
                     other is MeleeWeapon b
                     && CommonUtils.commonCompares(__instance, other)
                     && a.appearance.Value == b.appearance.Value
-                    && a.enchantments.Count == b.enchantments.Count
-                    && listContainsAll(a.enchantments, b.enchantments)
-                    && listContainsAll(a.enchantments, b.enchantments);
+                    && CommonUtils.equalEnchantLists(a.enchantments, b.enchantments);
             }
         }
         catch (Exception ex)
         {
             CommonUtils.harmonyExceptionPrint(ex);
         }
-    }
-
-    public static bool listContainsAll(
-        NetList<BaseEnchantment, NetRef<BaseEnchantment>> list,
-        NetList<BaseEnchantment, NetRef<BaseEnchantment>> otherList
-    )
-    {
-        for (int i = 0; i < list.Count; i++)
-        {
-            var found = false;
-            for (int j = 0; j < otherList.Count; j++)
-            {
-                if (
-                    list[i].GetType() == otherList[j].GetType()
-                    && list[i].GetLevel() == otherList[j].GetLevel()
-                )
-                {
-                    found = true;
-                    break;
-                }
-            }
-            if (!found)
-            {
-                return false;
-            }
-        }
-        return true;
     }
 }

--- a/StackMoreThings/Patches/Tool.cs
+++ b/StackMoreThings/Patches/Tool.cs
@@ -23,14 +23,18 @@ public static class ToolCanStackWith
     {
         try
         {
-            if (__instance is Tool a && CommonUtils.config.Tools && __instance is not MeleeWeapon)
+            if (
+                __instance is Tool a
+                && CommonUtils.config.Tools
+                && __instance is not MeleeWeapon
+                && a.AttachmentSlotsCount == 0
+            )
             {
                 __result =
                     other is Tool b
                     && CommonUtils.commonCompares(__instance, other)
                     && a.UpgradeLevel == b.UpgradeLevel
-                    && CommonUtils.equalEnchantLists(a.enchantments, b.enchantments)
-                    && a.AttachmentSlotsCount == 0;
+                    && CommonUtils.equalEnchantLists(a.enchantments, b.enchantments);
             }
         }
         catch (Exception ex)

--- a/StackMoreThings/Patches/Tool.cs
+++ b/StackMoreThings/Patches/Tool.cs
@@ -1,0 +1,62 @@
+using HarmonyLib;
+using StardewValley;
+using StardewValley.Tools;
+
+namespace StackMoreThings.Patches;
+
+[HarmonyPatch(typeof(Tool), nameof(Tool.maximumStackSize))]
+public static class ToolStackSize
+{
+    public static void Postfix(ref int __result, Tool __instance)
+    {
+        CommonUtils.setMaxStackSize(
+            ref __result,
+            CommonUtils.config.Tools && __instance.AttachmentSlotsCount == 0
+        );
+    }
+}
+
+[HarmonyPatch(typeof(Item), nameof(Item.canStackWith))]
+public static class ToolCanStackWith
+{
+    public static void Postfix(ISalable other, ref bool __result, Item __instance)
+    {
+        try
+        {
+            if (__instance is Tool a && CommonUtils.config.Tools && __instance is not MeleeWeapon)
+            {
+                __result =
+                    other is Tool b
+                    && CommonUtils.commonCompares(__instance, other)
+                    && a.UpgradeLevel == b.UpgradeLevel
+                    && CommonUtils.equalEnchantLists(a.enchantments, b.enchantments)
+                    && a.AttachmentSlotsCount == 0;
+            }
+        }
+        catch (Exception ex)
+        {
+            CommonUtils.harmonyExceptionPrint(ex);
+        }
+    }
+}
+
+[HarmonyPatch(typeof(Tool), nameof(Tool.canThisBeAttached), [typeof(StardewValley.Object)])]
+public static class FishingRodAttachment
+{
+    // Allows right click on fishing rod to unstack if they don't have
+    // attachment slots
+    public static void Postfix(StardewValley.Object o, ref bool __result, Tool __instance)
+    {
+        try
+        {
+            if (o == null && __instance.AttachmentSlotsCount == 0)
+            {
+                __result = false;
+            }
+        }
+        catch (Exception ex)
+        {
+            CommonUtils.harmonyExceptionPrint(ex);
+        }
+    }
+}

--- a/StackMoreThings/Patches/Tool.cs
+++ b/StackMoreThings/Patches/Tool.cs
@@ -47,7 +47,7 @@ public static class ToolCanStackWith
 [HarmonyPatch(typeof(Tool), nameof(Tool.canThisBeAttached), [typeof(StardewValley.Object)])]
 public static class FishingRodAttachment
 {
-    // Allows right click on fishing rod to unstack if they don't have
+    // Allows right click on fishing rod to unstack if it doesn't have
     // attachment slots
     public static void Postfix(StardewValley.Object o, ref bool __result, Tool __instance)
     {

--- a/StackMoreThings/i18n/default.json
+++ b/StackMoreThings/i18n/default.json
@@ -2,6 +2,7 @@
     "Stacks": "Stack Types",
     "SettingsInstructions": "Toggle stacking for individual items if something is buggy",
     "Weapons": "Weapons",
+    "Tools": "Tools",
     "MaxStackSize": "Maximum stack size for all items",
     "MaxStackSizeTooltip": "If the input is not a valid number, it will be set to 9999",
     "ColorMerge": "Merge colors",


### PR DESCRIPTION
Stacking for tools other as long as they don't have attachment slots.  In the base game this should just be higher tier fishing rods.  Not including them because of right clicking, and also because I don't want to think about bait/tackle use if someone uses a rod and how to merge two rods together


Untested other than build