### PR TITLE
[StackMoreThings] Stack tools while organizing + random stuff

### DIFF
--- a/StackMoreThings/ModEntry.cs
+++ b/StackMoreThings/ModEntry.cs
@@ -44,7 +44,7 @@ internal sealed class ModEntry : Mod
             {
                 int stackSize = 9999;
                 int.TryParse(value, out stackSize);
-                if (stackSize < 0)
+                if (stackSize <= 0)
                 {
                     stackSize = 9999;
                 }

--- a/StackMoreThings/Patches/Tool.cs
+++ b/StackMoreThings/Patches/Tool.cs
@@ -1,5 +1,6 @@
 using HarmonyLib;
 using StardewValley;
+using StardewValley.Menus;
 using StardewValley.Tools;
 
 namespace StackMoreThings.Patches;
@@ -11,7 +12,9 @@ public static class ToolStackSize
     {
         CommonUtils.setMaxStackSize(
             ref __result,
-            CommonUtils.config.Tools && __instance.AttachmentSlotsCount == 0
+            CommonUtils.config.Tools
+                && __instance.AttachmentSlotsCount == 0
+                && __instance is not MeleeWeapon
         );
     }
 }
@@ -28,6 +31,7 @@ public static class ToolCanStackWith
                 && CommonUtils.config.Tools
                 && __instance is not MeleeWeapon
                 && a.AttachmentSlotsCount == 0
+                && CommonUtils.config.EnableComplexPatches
             )
             {
                 __result =
@@ -53,7 +57,11 @@ public static class FishingRodAttachment
     {
         try
         {
-            if (o == null && __instance.AttachmentSlotsCount == 0)
+            if (
+                o == null
+                && __instance.AttachmentSlotsCount == 0
+                && CommonUtils.config.EnableComplexPatches
+            )
             {
                 __result = false;
             }
@@ -62,5 +70,49 @@ public static class FishingRodAttachment
         {
             CommonUtils.harmonyExceptionPrint(ex);
         }
+    }
+}
+
+[HarmonyPatch(typeof(ItemGrabMenu), nameof(ItemGrabMenu.organizeItemsInList))]
+public static class StackToolsWhileSorting
+{
+    public static bool Prefix(ref IList<Item> items)
+    {
+        try
+        {
+            if (!CommonUtils.config.EnableComplexPatches)
+            {
+                return true;
+            }
+            // Helps make sure we don't accidentally sort something that
+            // shouldn't be sorted?  Copied pretty much directly from game code
+            for (int i = 0; i < items.Count; i++)
+            {
+                Item item = items[i];
+                if (item is not Tool || item.getRemainingStackSpace() <= 0)
+                {
+                    continue;
+                }
+
+                for (int j = i + 1; j < items.Count; j++)
+                {
+                    Item item2 = items[j];
+                    if (item.canStackWith(item2))
+                    {
+                        item2.Stack = item.addToStack(item2);
+                        if (item2.Stack == 0)
+                        {
+                            items.RemoveAt(j);
+                            j--;
+                        }
+                    }
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            CommonUtils.harmonyExceptionPrint(ex);
+        }
+        return true;
     }
 }

--- a/StackMoreThings/Patches/Tool.cs
+++ b/StackMoreThings/Patches/Tool.cs
@@ -31,7 +31,6 @@ public static class ToolCanStackWith
                 && CommonUtils.config.Tools
                 && __instance is not MeleeWeapon
                 && a.AttachmentSlotsCount == 0
-                && CommonUtils.config.EnableComplexPatches
             )
             {
                 __result =

--- a/StackMoreThings/Patches/_Unused.cs
+++ b/StackMoreThings/Patches/_Unused.cs
@@ -3,7 +3,7 @@ using StardewValley;
 using StardewValley.Menus;
 using StardewValley.Objects;
 
-namespace StackMoreThings;
+namespace StackMoreThings.Patches;
 
 public class FarmerPatches
 {

--- a/StackMoreThings/README.md
+++ b/StackMoreThings/README.md
@@ -2,7 +2,7 @@
 
 Mod that allows you to stack things like furniture, tackle, clothing, etc. Also lets you adjust the maximum stack size for everything, merge crops of different colors into one stack, and reduce the quality of items so they can be stacked.
 
-Multiplayer has been reported as working but is untested by the author.
+Multiplayer has been reported as working.
 
 ## Config Options
 Supports Generic Mod Config Menu

--- a/StackMoreThings/README.md
+++ b/StackMoreThings/README.md
@@ -2,7 +2,7 @@
 
 Mod that allows you to stack things like furniture, tackle, clothing, etc. Also lets you adjust the maximum stack size for everything, merge crops of different colors into one stack, and reduce the quality of items so they can be stacked.
 
-Multiplayer has been reported as working from others but is untested by the author.
+Multiplayer has been reported as working but is untested by the author.
 
 ## Config Options
 Supports Generic Mod Config Menu
@@ -34,7 +34,7 @@ Some notes on expected behavior:
   * Dressers and fish tanks with things inside
   * Combined rings made of different rings
   * Weapons and tools with different enchantments
-  * Fishing rods that can have attachments
+  * Fishing rods that can have bait or tackle
   * Clothing of different color
   * Different colors of Cornucopia bell peppers (this may change in the future)
 * You can wear multiple rings and boots, but the effects will not stack

--- a/StackMoreThings/README.md
+++ b/StackMoreThings/README.md
@@ -2,7 +2,7 @@
 
 Mod that allows you to stack things like furniture, tackle, clothing, etc. Also lets you adjust the maximum stack size for everything, merge crops of different colors into one stack, and reduce the quality of items so they can be stacked.
 
-Likely to be incompatible with multiplayer.
+Multiplayer has been reported as working from others but is untested by the author.
 
 ## Config Options
 Supports Generic Mod Config Menu
@@ -18,6 +18,7 @@ There is one option for each of the previously unstackable things and are all en
 * Weapons
 * Rings
 * Tackle
+* Tools
 * Trinkets
 * Wallpaper
 
@@ -26,5 +27,17 @@ Two keybinds for merging colors and reducing quality:
 * QualityReduceKey - default F9
 
 Hold down these keys while organizing your inventory and chests to merge all colors of one crop into one so they can be stacked, or to reduce the quality of everything to none so they can be stacked.
+
+## Expected Behavior
+Some notes on expected behavior:
+* Things that do not stack:
+  * Dressers and fish tanks with things inside
+  * Combined rings made of different rings
+  * Weapons and tools with different enchantments
+  * Fishing rods that can have attachments
+  * Clothing of different color
+  * Different colors of Cornucopia bell peppers (this may change in the future)
+* You can wear multiple rings and boots, but the effects will not stack
+* Tackle will prioritize being placed on empty tackle spots if there are any
 
 Thanks to the Stardew Valley discord for their help with answering questions and code review.

--- a/StackMoreThings/manifest.json
+++ b/StackMoreThings/manifest.json
@@ -5,7 +5,7 @@
     "Description": "Stack things like trinkets, tackle, weapons, etc; merge colors and quality; adjust stack size.",
     "UniqueID": "gellingly.StackMoreThings",
     "EntryDll": "StackMoreThings.dll",
-    "MinimumApiVersion": "4.0.0",
+    "MinimumApiVersion": "4.1.0",
     "UpdateKeys": [
         "Nexus:32562"
     ]


### PR DESCRIPTION
Organizing chest/inventory will now stack tools

Other random stuff:
* updates to readme: tools, multiplayer, expected behavior
* increment version number
* 0 stack size -> 9999 (default)
* checks for complex patches I forgot
* checks that tools are not weapons I forgot (not sure if this is necessary but doesn't hurt to be safe)
* wrong namespace 
